### PR TITLE
Resolve #8

### DIFF
--- a/lib/capistrano/graphite/version.rb
+++ b/lib/capistrano/graphite/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Graphite
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
Sets default for graphite_enable_events by extending the `:defualt` task in
Capistrano's `:load` method
Bumps gem version to 0.1.2.
