### PR TITLE
Set defaults only when they are empty

### DIFF
--- a/lib/capistrano/graphite.rb
+++ b/lib/capistrano/graphite.rb
@@ -50,7 +50,7 @@ end
 
 namespace :load do
   task :defaults do
-    set :suppress_graphite_events, 'false'
-    set :local_user, ENV['USER']
+    set_if_empty :suppress_graphite_events, 'false'
+    set_if_empty :local_user, ENV['USER']
   end
 end


### PR DESCRIPTION
So the project can override then in top level configuration.