### PR TITLE
Fix suppress_graphite_events option

### DIFF
--- a/lib/capistrano/graphite.rb
+++ b/lib/capistrano/graphite.rb
@@ -28,13 +28,13 @@ namespace :deploy do
   task :post_graphite, :action do |_, args|
     action = args[:action]
     run_locally do
-      if fetch(:suppress_graphite_events).downcase == 'true'
+      if fetch(:suppress_graphite_events).downcase == 'false'
         GraphiteInterface.new.post_event("#{action}")
         info("#{action.capitalize} event posted to graphite.")
-      elsif fetch(:suppress_graphite_events).downcase == 'false'
-        info('No event posted: `suppress_graphite_events` set to true.')
+      elsif fetch(:suppress_graphite_events).downcase == 'true'
+        info('No event posted: `suppress_graphite_events` is set to true.')
       else
-        warn('No event posted: `suppress_graphite_events` set incorrectly.')
+        warn('No event posted: `suppress_graphite_events` is set incorrectly.')
       end
     end
   end


### PR DESCRIPTION
post_graphite task was doing exactly the opposite of what
`suppress_graphite_events` option means.

Fixes #26