### PR TITLE
Add ssl to graphite post if https is used.

### DIFF
--- a/lib/capistrano/graphite.rb
+++ b/lib/capistrano/graphite.rb
@@ -14,7 +14,8 @@ class GraphiteInterface
     req.basic_auth(uri.user, uri.password) if uri.user
     req.body = event(action).to_json
 
-    Net::HTTP.start(uri.host, uri.port) do |http|
+    opts = { use_ssl: uri.scheme == 'https', verify_mode: fetch(:graphite_ssl_verify) }
+    Net::HTTP.start(uri.host, uri.port, opts) do |http|
       http.request(req)
     end
   end
@@ -64,5 +65,6 @@ namespace :load do
     set :graphite_event_msg, (lambda do |action|
       "#{action} #{fetch(:application)} in #{fetch(:stage)}"
     end)
+    set :graphite_ssl_verify, OpenSSL::SSL::VERIFY_PEER
   end
 end

--- a/lib/capistrano/graphite.rb
+++ b/lib/capistrano/graphite.rb
@@ -14,7 +14,8 @@ class GraphiteInterface
     req.basic_auth(uri.user, uri.password) if uri.user
     req.body = event(action).to_json
 
-    opts = { use_ssl: uri.scheme == 'https', verify_mode: fetch(:graphite_ssl_verify) }
+    opts = { use_ssl: uri.scheme == 'https',
+             verify_mode: fetch(:graphite_ssl_verify) }
     Net::HTTP.start(uri.host, uri.port, opts) do |http|
       http.request(req)
     end


### PR DESCRIPTION
I added support for ssl on https requests. There is a `:graphite_ssl_verify` flag that can be used to set the level of certificate verification used. It accepts any of the verification constants from the `OpenSSL::SSL` module, and defaults to `OpenSSL::SSL::VERIFY_PEER`.