### PR TITLE
Expose all of the Net::HTTP options to the user

### DIFF
--- a/lib/capistrano/graphite.rb
+++ b/lib/capistrano/graphite.rb
@@ -14,8 +14,8 @@ class GraphiteInterface
     req.basic_auth(uri.user, uri.password) if uri.user
     req.body = event(action).to_json
 
-    opts = { use_ssl: uri.scheme == 'https',
-             verify_mode: fetch(:graphite_ssl_verify) }
+    opts = fetch(:graphite_http_options)
+
     Net::HTTP.start(uri.host, uri.port, opts) do |http|
       http.request(req)
     end
@@ -66,6 +66,6 @@ namespace :load do
     set :graphite_event_msg, (lambda do |action|
       "#{action} #{fetch(:application)} in #{fetch(:stage)}"
     end)
-    set :graphite_ssl_verify, OpenSSL::SSL::VERIFY_PEER
+    set :graphite_http_options, verify_mode: OpenSSL::SSL::VERIFY_PEER
   end
 end


### PR DESCRIPTION
This changes the `:graphite_ssl_verify` option to `:graphite_http_options`, which is a hash of options to supply to Net::HTTP. This exposes all of the connection options, so the user can specify whatever options are needed for their environment (such as `ca_path`). This still preserves the behavior and options of version 1.0.5 by default.