### PR TITLE
Make HTTPS urls work by default

### DIFF
--- a/lib/capistrano/graphite.rb
+++ b/lib/capistrano/graphite.rb
@@ -14,7 +14,7 @@ class GraphiteInterface
     req.basic_auth(uri.user, uri.password) if uri.user
     req.body = event(action).to_json
 
-    opts = fetch(:graphite_http_options)
+    opts = { use_ssl: uri.scheme == 'https' }.merge(fetch(:graphite_http_options))
 
     Net::HTTP.start(uri.host, uri.port, opts) do |http|
       http.request(req)


### PR DESCRIPTION
The POST to Graphite was failing if the URL was HTTPS, unless you
manually set `use_ssl` to true in `graphite_http_options`.

This change populates a reasonable default for `use_ssl` based on the
given `graphite_url` - this appears to have been the behavior added
in #30 but later broken in #31. If someone explicitly sets `use_ssl`,
their setting will override the default.