### PR TITLE
Require json for `.to_json`

### DIFF
--- a/lib/capistrano/graphite.rb
+++ b/lib/capistrano/graphite.rb
@@ -5,6 +5,7 @@ require 'net/http'
 require 'uri'
 require 'sshkit'
 require 'sshkit/dsl'
+require 'json'
 
 # Build the request to post
 class GraphiteInterface


### PR DESCRIPTION
Multiple things are pulling in 'json' which is why this doesn't show up
in the tests, but it is not explicitly required in the code and it is required for `to_json` to work.

``` sh-session
$ ruby -e 'a = {foo: 3}.to_json; puts a'
-e:1:in `<main>': undefined method `to_json' for {:foo=>3}:Hash (NoMethodError)

$ ruby -e 'require "json"; a = {foo: 3}.to_json; puts a'
{"foo":3}
```
